### PR TITLE
ctypes: fix compat with 0.21.0

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 <**/*.ml{,i}>: bin_annot
 
 <src>: include
-<src/udev.ml{,i}>: package(ctypes), package(stdint), package(unix)
+<src/udev.ml{,i}>: package(ctypes), package(ctypes.foreign), package(stdint), package(unix)
 <src/udev.{cma,cmxa,cmxs}>: custom, package(ctypes), package(ctypes.foreign), use_libudev
 <src/libudev_stubs.*>: use_libudev
 


### PR DESCRIPTION
In ctypes < 0.21.0, the ctypes and ctypes.foreign libraries were installed in the same directory, so depending on one would make the other one visible.
ctypes 0.21.0 installs them in different directories so this makes it an error.
udev.ml actually uses ctypes.foreign so it should depend on it.
